### PR TITLE
Add subcommands for wp-cli, logs, stopping, and status

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,11 +33,11 @@ x-php: &php
     AWS_XRAY_DAEMON_HOST: xray
     S3_UPLOADS_ENDPOINT: http://s3.localhost:8000/
     S3_UPLOADS_BUCKET: s3-${COMPOSE_PROJECT_NAME:-default}
-    S3_UPLOADS_BUCKET_URL: http://s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev
+    S3_UPLOADS_BUCKET_URL: https://s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev
     S3_UPLOADS_KEY: not-needed
     S3_UPLOADS_SECRET: not-needed
     S3_UPLOADS_REGION: not-needed
-    TACHYON_URL: http://tachyon-${COMPOSE_PROJECT_NAME:-default}.altis.dev/uploads
+    TACHYON_URL: https://tachyon-${COMPOSE_PROJECT_NAME:-default}.altis.dev/uploads
 
 services:
   db:

--- a/inc/Composer/Command.php
+++ b/inc/Composer/Command.php
@@ -3,32 +3,131 @@
 namespace HM\Platform\LocalServer\Composer;
 
 use Composer\Command\BaseCommand;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 class Command extends BaseCommand {
 	protected function configure() {
-		$this->setName( 'local-server' );
+		$this->setName( 'local-server' )
+			->setDescription( 'Local server.' )
+			->setDefinition( [
+				new InputArgument( 'subcommand', null, 'start, stop, cli, status. logs.' ),
+				new InputArgument( 'options', InputArgument::IS_ARRAY ),
+			] )
+			->setHelp(
+				<<<EOT
+Run the local development server.
+
+To start the local development server:
+	start
+Stop the local development server:
+	stop
+View status of the local development server:
+	status
+Run WP CLI command:
+	cli -- <command>              eg: cli -- post list --debug
+View the logs
+	logs <service>                <service> can be php, nginx, db, s3, elasticsearch, xray
+EOT
+			);
+	}
+
+	public function isProxyCommand() {
+		return true;
 	}
 
 	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$subcommand = $input->getArgument( 'subcommand' );
+
+		if ( $subcommand === 'start' ) {
+			return $this->start( $input, $output );
+		} elseif ( $subcommand === 'stop' ) {
+			return $this->stop( $input, $output );
+		} elseif ( $subcommand === 'cli' ) {
+			return $this->cli( $input, $output );
+		} elseif ( $subcommand === 'status' ) {
+			return $this->status( $input, $output );
+		} elseif ( $subcommand === 'logs' ) {
+			return $this->logs( $input, $output );
+		}
+	}
+
+	protected function start( InputInterface $input, OutputInterface $output ) {
 		$output->writeln( 'Starting...' );
 
-		$proxy = new Process( 'docker-compose -f proxy.yml up', 'vendor/humanmade/local-server/docker' );
-		$proxy->setTimeout( 0 );
-		$proxy->start();
+		$proxy = new Process( 'docker-compose -f proxy.yml up -d', 'vendor/humanmade/local-server/docker' );
+		$proxy->run();
 
-		$compose = new Process( 'docker-compose up', 'vendor/humanmade/local-server/docker', [
+		$compose = new Process( 'docker-compose up -d', 'vendor/humanmade/local-server/docker', [
 			'VOLUME' => getcwd(),
 			'COMPOSE_PROJECT_NAME' => basename( getcwd() ),
 		] );
 		$compose->setTimeout( 0 );
-
-		$compose->start( function ( $type, $buffer ) {
+		$compose->run( function ( $type, $buffer ) {
 			echo $buffer;
 		} );
 
-		$compose->wait();
+		$site_url = 'https://' . basename( getcwd() ) . '.altis.dev/';
+		$output->writeln( 'Startup completed.' );
+		$output->writeln( 'To access your site visit: ' . $site_url );
+	}
+
+	protected function stop( InputInterface $input, OutputInterface $output ) {
+		$output->writeln( 'Stopping...' );
+
+		$proxy = new Process( 'docker-compose down', 'vendor/humanmade/local-server/docker' );
+		$proxy->run();
+
+		$compose = new Process( 'docker-compose down', 'vendor/humanmade/local-server/docker', [
+			'VOLUME' => getcwd(),
+			'COMPOSE_PROJECT_NAME' => basename( getcwd() ),
+		] );
+		$compose->run( function ( $type, $buffer ) {
+			echo $buffer;
+		} );
+
+		$output->writeln( 'Stopped...' );
+	}
+
+	protected function cli( InputInterface $input, OutputInterface $output ) {
+		$site_url = 'https://' . basename( getcwd() ) . '.altis.dev/';
+
+		$options = $input->getArgument( 'options' );
+		$options[] = '--url=' . $site_url;
+
+		passthru( sprintf(
+			'cd %s; VOLUME=%s COMPOSE_PROJECT_NAME=%s docker-compose exec %s -u nobody php wp %s',
+			'vendor/humanmade/local-server/docker',
+			getcwd(),
+			basename( getcwd() ),
+			! posix_isatty( STDOUT ) ? '-T' : '', // forward wp-cli's isPiped detection
+			implode( ' ', $options )
+		), $return_val );
+
+		return $return_val;
+	}
+
+	protected function status( InputInterface $input, OutputInterface $output ) {
+		$compose = new Process( 'docker-compose ps', 'vendor/humanmade/local-server/docker', [
+			'VOLUME' => getcwd(),
+			'COMPOSE_PROJECT_NAME' => basename( getcwd() ),
+		] );
+		$compose->run( function ( $type, $buffer ) {
+			echo $buffer;
+		} );
+	}
+
+	protected function logs( InputInterface $input, OutputInterface $output ) {
+		$log = $input->getArgument( 'options' )[0];
+		$compose = new Process( 'docker-compose logs -f ' . $log , 'vendor/humanmade/local-server/docker', [
+			'VOLUME' => getcwd(),
+			'COMPOSE_PROJECT_NAME' => basename( getcwd() ),
+		] );
+		$compose->run( function ( $type, $buffer ) {
+			echo $buffer;
+		} );
 	}
 }


### PR DESCRIPTION
Change the local-server to use subcommands: start, stop, status, cli, logs

Help section now:

```
Help:
  Run the local development server.

  To start the local development server:
  	start
  Stop the local development server:
  	stop
  View status of the local development server:
  	status
  Run WP CLI command:
  	cli -- <command>              eg: cli -- post list --debug
  View the logs
  	logs <service>                <service> can be php, nginx, db, s3, elasticsearch, xray
```

There's a bit of a niggle on how the cli arguments have to be passed. you can do `cli posts list`, but you have to do `cli -- posts list --url=some-site`, otherwise the `--url` option will be parsed by composer and fail.